### PR TITLE
Improve/kill test

### DIFF
--- a/contracts/interface/IStayking.sol
+++ b/contracts/interface/IStayking.sol
@@ -24,6 +24,8 @@ interface IStayking {
 
     function liquidateDebtFactorBps() external view returns(uint256);
 
+    function liquidationFeeBps() external view returns(uint256);
+
     function reservedBps() external view returns(uint256);
 
     function debtAmountOf (
@@ -43,42 +45,10 @@ interface IStayking {
     /// @param debtToken    debtToken Address (not vault address)
     function removePosition(address debtToken) external;
 
-    // deprecated
-    // /// @dev Borrow more debt (increase debt ratio)
-    // /// @param debtToken    debtToken Address (not vault address)
-    // /// @param extraDebtInBase  amount of additional debt in EVMOS
-    // function addDebt(
-    //     address debtToken,
-    //     uint256 extraDebtInBase
-    // ) external;
-
-    // /// @dev Repay debt (decrease debt ratio)
-    // /// @notice user should repay debt using debtToken
-    // /// @notice user approve should be preceded
-    // /// @param debtToken    debtToken Address (not vault address)
-    // /// @param repaidDebt  amount of repaid debt in debtToken
-    // function repayDebt(
-    //     address debtToken,
-    //     uint256 repaidDebt
-    // ) external;
-
-    // function repayDebtInBase(
-    //     address debtToken,
-    //     uint256 minRepaid
-    // ) payable external;
-
-    // /// @dev add additional equity (decrease debt ratio)
-    // /// @param debtToken    debtToken Address (not vault address)
-    // /// @param extraEquity  amount of additional equity
-    // function addEquity(
-    //     address debtToken,
-    //     uint256 extraEquity
-    // ) payable external;
-
     function positionInfo(
         address user,
         address vault
-    ) external view returns (uint256 equityInBase, uint256 debtInBase, uint256 debt);
+    ) external view returns (uint256 equityInBase, uint256 debtInBase, uint256 debt, uint256 positionId);
 
     function isKillable(address debtToken, uint256 positionId) external view returns(bool);
     

--- a/contracts/mock/MockSwap.sol
+++ b/contracts/mock/MockSwap.sol
@@ -20,6 +20,7 @@ contract MockSwap is Ownable {
      */
 
     mapping(address => bool) public isSupported;
+    uint256 public EVMOSpriceBps;
 
     constructor (
         address[] memory tokens
@@ -27,17 +28,19 @@ contract MockSwap is Ownable {
         for (uint256 i = 0; i < tokens.length; i++) {
             isSupported[tokens[i]] = true;
         }
+
+        EVMOSpriceBps = 20000;
     }
 
     function getDx(
         address tokenX,
         address tokenY,
         uint256 dy
-    ) public pure returns (uint256) {
+    ) public view returns (uint256) {
         if(tokenX == address(0))
-            return dy / 2;
+            return dy * 1E4 / EVMOSpriceBps;
         else if(tokenY == address(0))
-            return dy * 2;
+            return dy * EVMOSpriceBps / 1E4;
         else
             return dy;
     }
@@ -46,11 +49,11 @@ contract MockSwap is Ownable {
         address tokenX,
         address tokenY,
         uint256 dx
-    ) public pure returns (uint256) {
+    ) public view returns (uint256) {
         if(tokenX == address(0))
-            return dx * 2;
+            return dx * EVMOSpriceBps / 1E4;
         else if(tokenY == address(0))
-            return dx / 2;
+            return dx * 1E4 / EVMOSpriceBps;
         else
             return dx;
     }
@@ -78,6 +81,13 @@ contract MockSwap is Ownable {
     // sweep in-contract EVMOS
     function sweep() public onlyOwner {
         SafeToken.safeTransferEVMOS(msg.sender, address(this).balance);
+    }
+
+    function changeRatio(
+        uint256 newRatio
+    ) public onlyOwner {
+        require(newRatio > 0, "newRatio <= 0");
+        EVMOSpriceBps = newRatio;
     }
 
     fallback() external payable {}

--- a/contracts/token/Vault.sol
+++ b/contracts/token/Vault.sol
@@ -253,11 +253,11 @@ contract Vault is IVault, ERC20Upgradeable, OwnableUpgradeable {
         return swapHelper.getDx(BASE_TOKEN, token, tokenOut);
     }
 
-    /// @dev calc $ EVMOS = (?)token
+    /// @dev calc $ token = (?)EVMOS
     function getBaseOut(
-        uint256 tokenIn
-    ) public override view returns(uint256 baseOut) {
-        return swapHelper.getDy(BASE_TOKEN, token, tokenIn);
+        uint256 baseIn
+    ) public override view returns(uint256 tokenOut) {
+        return swapHelper.getDy(token, BASE_TOKEN, baseIn);
     }
 
     /// @dev calc (?)token = $ EVMOS
@@ -266,13 +266,14 @@ contract Vault is IVault, ERC20Upgradeable, OwnableUpgradeable {
     ) public override view returns(uint256 tokenIn) {
         return swapHelper.getDx(token, BASE_TOKEN, baseOut);
     }
-    
-    /// @dev calc $ token = (?)EVMOS
+
+    /// @dev calc $ EVMOS = (?)token
     function getTokenOut(
-        uint256 baseIn
-    ) public override view returns(uint256 tokenOut) {
-        return swapHelper.getDy(token, BASE_TOKEN, baseIn);
+        uint256 tokenIn
+    ) public override view returns(uint256 baseOut) {
+        return swapHelper.getDy(BASE_TOKEN, token, tokenIn);
     }
+
     
     /************************************
      * interface IVault Implementations


### PR DESCRIPTION
# 반영 브랜치
main

# 변경 사항
- Vault에서 환율 계산하는 함수 중에 `getBaseOut` 함수와 `getTokenOut`의 기능이 바뀌어 있었던 것을 확인해서 고쳐두었습니다.
- 강제 청산 시 Stayking으로 liquidation fee가 징수되도록 liquidationFeeBps 변수를 추가했습니다.
- `positionInfo` 함수에서 positionId 값도 리턴하도록 변경했습니다.
- Kill function에 대한 테스트 코드를 추가하였습니다.
- MockSwap에 `changeRatio` 함수를 추가하여 EVMOS - USDC 환율을 조정할 수 있도록 변경하였습니다. 이를 활용하면 청산 상황을 연출해낼 수 있습니다.

# 확인 방법 (스크린샷 포함)
