### PR TITLE
[Feat] Update distributing interests & APR view function

### DIFF
--- a/contracts/interface/IStayking.sol
+++ b/contracts/interface/IStayking.sol
@@ -20,13 +20,15 @@ interface IStayking {
     /// @dev min debtAmount in EVMOS (base token)
     function minDebtInBase() external view returns (uint256);
 
+    function reservedBps() external view returns(uint256);
+
+    function vaultRewardBps() external view returns(uint256);
+
     function killFactorBps() external view returns(uint256);
 
     function liquidateDebtFactorBps() external view returns(uint256);
 
     function liquidationFeeBps() external view returns(uint256);
-
-    function reservedBps() external view returns(uint256);
 
     function debtAmountOf (
         address user,

--- a/contracts/interface/IVault.sol
+++ b/contracts/interface/IVault.sol
@@ -21,14 +21,20 @@ interface IVault {
     
     function totalDebtAmount() external view returns(uint256);
 
+    function totalPendingDebtAmount() external view returns(uint256);
+
+    function totalPendingDebtShare() external view returns(uint256);
+
     function accInterest() external view returns(uint256);
+
+    function minReservedBps() external view returns(uint256);
+
+    function lastAccruedAt() external view returns(uint256);
 
     function utilizationRateBps() external view returns(uint256);
 
     /// @dev denominator = 1E18 
     function getInterestRate() external view returns(uint256);
-
-    function saveUtilizationRateBps() external;
 
     function deposit(uint256 amount) external returns(uint256 share);
 

--- a/contracts/token/Vault.sol
+++ b/contracts/token/Vault.sol
@@ -116,9 +116,9 @@ contract Vault is IVault, ERC20Upgradeable, OwnableUpgradeable {
         });
     }
 
-    function lastAPR() public view returns(uint256) {
+    function lastAnnualRateBps() public view returns(uint256) {
         // 31536000 = 365 * 24 * 60 * 60
-        return 31536000 * lastPaid.reward / lastPaid.totalAmount / uint256(lastPaid.interval);
+        return 315360000000 * lastPaid.reward / lastPaid.totalAmount / uint256(lastPaid.interval);
     }
 
     // @dev (token in vault) + (debt)

--- a/test/index.ts
+++ b/test/index.ts
@@ -498,7 +498,7 @@ describe('EVMOS Hackathon Test', async () => {
             await mockValidator.handleTx(tx);
 
             expect(await Stayking.totalAmount()).to.equal(mockValidator.amount);
-            expect(mockValidator.amount.sub(beforeStaked)).to.equal(expectedAccrued);
+            expect(mockValidator.amount.sub(beforeStaked)).to.approximately(expectedAccrued, toBN(1, 4));
         })
 
         it("After accrued, every position's debt ratio should be decreased", async function(){

--- a/test/index.ts
+++ b/test/index.ts
@@ -284,37 +284,9 @@ describe('EVMOS Hackathon Test', async () => {
 
             expect(userDebt.mul(1E4).div(totalLended.add(userDebt))).to.equal(ur);
         })
-
-        it("saves utilization rate on next day.", async function(){
-            const beforeYesterdayUR = await ibtUSDC.yesterdayUtilRate();
-
-            // 1. after 1 hour
-            await toNextHour()
-            await ibtUSDC.saveUtilizationRateBps();
-            // 1 hour later, yesterday util rate not changes
-            expect(await ibtUSDC.yesterdayUtilRate()).to.equal(beforeYesterdayUR)
-            
-            // 2. after +12 hours (after 1 day)
-            await timeTravel(43200);
-            await ibtUSDC.saveUtilizationRateBps();
-
-            // 1 day later, yesterday util rate changed
-            expect(await ibtUSDC.yesterdayUtilRate())
-                .to.equal(await ibtUSDC.utilizationRateBps());
-        })
     })
 
     describe("3. Lock uEVMOS", async function (){
-        // function toLocked(lock:UnbondedEvmos.LockedStructOutput){
-        //     return {
-        //         received: lock.received,
-        //         account: lock.account,
-        //         vault: lock.vault,
-        //         share: lock.share.toString(),
-        //         debtShare: lock.debtShare.toString(),
-        //         unlockedAt: new Date(lock.unlockedAt.toNumber() * 1000)
-        //     }
-        // }
         it("Remove Position", async function (){
             const [beforePosVaule, beforeDebtInBase, ] = await Stayking.positionInfo(staker1.address, tUSDC.address);
             


### PR DESCRIPTION
# 반영 브랜치
main

# 변경 사항

### 이자수익 분배
- 수익 분배의 과정(우선순위)은 다음과 같습니다.

1. 프로토콜(Stayking) 매출
  -> 전체 reward 중 (**`reservedBps/ 100`** )% 만큼을 매출로 저장
2. Vault Interest(정규 이자 calc by **`interestModel`**)
    (1) "전체 reward 중 N%"가 아닌 고정된 양이므로, 남은 reward로는 interest를 지급하지 못할 수 있다.     
          이 경우, **`(전체 reward - 매출) 전량`** 을 Vault Interest로 지급.
    (2) 정상적인 경우 (매출을 제외한) reward가 Vault Interest보다 크다.
3. Vault reward / Reinvested Amount
    2-(2)의 경우 reward에서 매출/이자를 제하고 남은 금액 중 (**`vaultRewardBps / 100`** )%는 
    Vault에 보너스 reward로 지급하고, 나머지는 Reinvest한다.

### APR
전날 기준, 각 Vault별 APR을 확인하는 방법은 아래 함수를 이용해 주세요.
  ```
  Vault.lastAnnualRateBps()
  ```

### APY
  ```
  APY = (1 + APR / 365) ^ 365 -1 ≈ e^APR - 1
  ```

# 테스트
```
npm run test test
```
