### PR TITLE
fixed apr divided by zero error

### DIFF
--- a/contracts/token/Vault.sol
+++ b/contracts/token/Vault.sol
@@ -117,6 +117,9 @@ contract Vault is IVault, ERC20Upgradeable, OwnableUpgradeable {
     }
 
     function lastAnnualRateBps() public view returns(uint256) {
+        if(lastPaid.totalAmount == 0 || uint256(lastPaid.interval) == 0){
+            return 0;
+        }
         // 31536000 = 365 * 24 * 60 * 60
         return 315360000000 * lastPaid.reward / lastPaid.totalAmount / uint256(lastPaid.interval);
     }


### PR DESCRIPTION
# 반영 브랜치
main

# 변경 사항
Vault.sol의 `lastAnnualRateBps` 함수 중 divided by zero 에러 해결

# 확인 방법 (스크린샷 포함)
N/A